### PR TITLE
Upgrade target framework from .NET Core 3.1 to .NET 10 (LTS)

### DIFF
--- a/cryptography.tests/cryptography.tests.csproj
+++ b/cryptography.tests/cryptography.tests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/cryptography/cryptography.csproj
+++ b/cryptography/cryptography.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #1

## What

Retargets both projects from `netcoreapp3.1` (EOL since Dec 2022) to **`net10.0`** (current LTS, supported to Nov 2028) and refreshes the test packages.

| File | Change |
|------|--------|
| `cryptography/cryptography.csproj` | TFM → `net10.0` |
| `cryptography.tests/cryptography.tests.csproj` | TFM → `net10.0`; `Microsoft.NET.Test.Sdk` 16.5.0→18.6.0, `NUnit` 3.12.0→3.14.0, `NUnit3TestAdapter` 3.16.1→6.2.0; removed legacy `Microsoft.VisualStudio.TestPlatform` |
| `.vscode/launch.json` | Debug path `netcoreapp3.1`→`net10.0` (git-ignored, applied locally) |

Stayed on **NUnit 3.14** (not 4.x) deliberately — the suite uses classic `Assert.AreEqual`-style asserts, so this required **no test-code changes**.

## Verification (.NET 10.0.108 SDK on Ubuntu 24.04)

- ✅ `dotnet build` — 0 errors
- ✅ `dotnet test` — **70/70 pass**, no test code modified
- ✅ Smoke test — Caesar encode→decode round-trip returns the original plaintext

## Follow-up (out of scope)

- ⚠️ Build emits `SYSLIB0023`: `RNGCryptoServiceProvider` (in `KeyGenerationService`) is obsolete; should migrate to `RandomNumberGenerator`. Non-blocking — compiles and runs.
- Pre-existing: ciphers call `File.WriteAllTextAsync(...)` fire-and-forget without awaiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)