### PR TITLE
Replace obsolete RNGCryptoServiceProvider with RandomNumberGenerator

### DIFF
--- a/cryptography/Services/KeyGenerationService.cs
+++ b/cryptography/Services/KeyGenerationService.cs
@@ -18,13 +18,9 @@ namespace cryptography.Services
 
             do
             {
-                RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
-                var byteArray = new byte[4];
-                provider.GetBytes(byteArray);
+                var randomInteger = RandomNumberGenerator.GetInt32(1, 27);
 
-                var randomInteger = (BitConverter.ToInt32(byteArray, 0) % 26) + 1;
-
-                if (!keyPlacement.Contains(randomInteger) && (randomInteger < 27 && (randomInteger > 0))) {
+                if (!keyPlacement.Contains(randomInteger)) {
                     keyPlacement.Add(randomInteger);
                 }
             } while (keyPlacement.Count < 26);


### PR DESCRIPTION
Closes #3

## What

`KeyGenerationService.generateRandomKey()` used `RNGCryptoServiceProvider`, obsolete in modern .NET — it emitted `SYSLIB0023` on build. Replaced with the static `RandomNumberGenerator.GetInt32(1, 27)`, which returns a bias-free integer in `[1, 26]` directly.

This also removes:
- the manual `byte[4]` buffer and `provider.GetBytes(...)`
- the `BitConverter.ToInt32(...) % 26` conversion (which could go negative)
- the redundant `randomInteger < 27 && randomInteger > 0` guard that silently discarded out-of-range values and wasted loop iterations

```diff
-                RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
-                var byteArray = new byte[4];
-                provider.GetBytes(byteArray);
-
-                var randomInteger = (BitConverter.ToInt32(byteArray, 0) % 26) + 1;
-
-                if (!keyPlacement.Contains(randomInteger) && (randomInteger < 27 && (randomInteger > 0))) {
+                var randomInteger = RandomNumberGenerator.GetInt32(1, 27);
+
+                if (!keyPlacement.Contains(randomInteger)) {
```

## Verification (.NET 10.0.108)

- ✅ `dotnet build` — **0 warnings, 0 errors** (SYSLIB0023 resolved)
- ✅ `dotnet test` — **70/70 pass**, no test code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)