### PR TITLE
Use synchronous File.WriteAllText in ciphers (fix fire-and-forget writes)

### DIFF
--- a/cryptography/HistoricCiphers/CaesarCipher.cs
+++ b/cryptography/HistoricCiphers/CaesarCipher.cs
@@ -40,14 +40,14 @@ namespace cryptography.HistoricCiphers
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceValues(fileString, skip);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         private static void decode (int skip, string readFromFile, string writeToFile) {
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceValues(fileString, 26-skip);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         public static string replaceValues(string fileString, int skip){

--- a/cryptography/HistoricCiphers/PlayfairCipher.cs
+++ b/cryptography/HistoricCiphers/PlayfairCipher.cs
@@ -56,7 +56,7 @@ namespace cryptography.HistoricCiphers
             var message = prepMessage(fileString);
             var output = replaceValues(message, key, true);
             printMessage(output, true);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace cryptography.HistoricCiphers
             var message = dSplitMessage(fileString);
             var output = replaceValues(message, key, false);
             printMessage(output, false);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         /// <summary>

--- a/cryptography/HistoricCiphers/RailFenceCipher.cs
+++ b/cryptography/HistoricCiphers/RailFenceCipher.cs
@@ -46,7 +46,7 @@ namespace cryptography.HistoricCiphers
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceValuesE(fileString, depth);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace cryptography.HistoricCiphers
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceValsD(fileString, depth);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         /// <summary>

--- a/cryptography/HistoricCiphers/SimpleSubCipher.cs
+++ b/cryptography/HistoricCiphers/SimpleSubCipher.cs
@@ -45,7 +45,7 @@ namespace cryptography.HistoricCiphers
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceVals(fileString, key, false);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         private void decode (List<char> key, string readFromFile, string writeToFile) {
@@ -53,7 +53,7 @@ namespace cryptography.HistoricCiphers
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceVals(fileString, key, true);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         private static string replaceVals(string fileString, List<char> key, bool decode)

--- a/cryptography/HistoricCiphers/SimpleTranspositionCipher.cs
+++ b/cryptography/HistoricCiphers/SimpleTranspositionCipher.cs
@@ -43,7 +43,7 @@ namespace cryptography.HistoricCiphers
             var fileString = File.ReadAllText(readFromFile);
             var output = replaceVals(fileString, key);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
         
         private void decode (int key, string readFromFile, string writeToFile) {
@@ -52,7 +52,7 @@ namespace cryptography.HistoricCiphers
             key = fileString.Length / key;
             var output = replaceVals(fileString, key);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         private string replaceVals(string fileString, int key)

--- a/cryptography/HistoricCiphers/VigenereCipher.cs
+++ b/cryptography/HistoricCiphers/VigenereCipher.cs
@@ -45,7 +45,7 @@ namespace cryptography.HistoricCiphers
             var key = generateFullKey(fileString.Length, keyPhrase);
             var output = replaceValues(fileString, key, true);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
         private void decode (List<char> keyPhrase, string readFromFile, string writeToFile) {
             
@@ -53,7 +53,7 @@ namespace cryptography.HistoricCiphers
             var key = generateFullKey(fileString.Length, keyPhrase);
             var output = replaceValues(fileString, key, false);
             Console.WriteLine(output);
-            File.WriteAllTextAsync(writeToFile, output);
+            File.WriteAllText(writeToFile, output);
         }
 
         private string replaceValues(string fileString, List<char> key, bool encrypt)


### PR DESCRIPTION
Closes #6

## What

Every cipher wrote output via `File.WriteAllTextAsync(...)` **without awaiting** the returned `Task`. Since the enclosing `encode`/`decode` methods are synchronous `void`, the write could fail to flush before the method returned, and any I/O exception was silently swallowed.

Switched all **12 call sites** (encode + decode across the 6 ciphers) to synchronous `File.WriteAllText`, which completes before returning. No async benefit was being gained in this single-threaded console app.

### Files
- `CaesarCipher.cs`, `VigenereCipher.cs`, `SimpleSubCipher.cs`, `SimpleTranspositionCipher.cs`, `RailFenceCipher.cs`, `PlayfairCipher.cs` (2 calls each)

## Verification (.NET 10.0.108)

- ✅ `dotnet build` — 0 warnings, 0 errors
- ✅ `dotnet test` — **70/70 pass**, no test code changed
- ✅ `grep WriteAllTextAsync` in `HistoricCiphers/` — no matches
- ✅ Caesar encode → decode round-trip returns the original plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)