### PR TITLE
Overhaul README with usage, structure, and accurate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,99 @@
 # Cryptography
 
-C# Console app to exercise cryptographic algorithms. 
+A C# console application for exploring cryptographic algorithms, built as a learning exercise to better understand how they work. It currently implements a range of historic ciphers and supporting number-theory calculations, with the intention of growing towards more modern algorithms over time.
 
-This project was created as a learning exercise to better understand cryptographic algorithms. It started with historic algorithms and the plan is to continue it to implement more modern algorithms. 
+## ⚠️ Educational use only
+
+These are **historic, broken-by-design ciphers** implemented for learning purposes. They provide **no real security** and must **never** be used to protect sensitive data. Use a vetted library (e.g. the modern primitives in `System.Security.Cryptography`) for anything real.
+
+## Prerequisites
+
+- [.NET SDK 10.0](https://dotnet.microsoft.com/download) or later
+
+Check your installed SDK with:
+
+```bash
+dotnet --list-sdks
+```
+
+## Build and test
+
+```bash
+# Restore dependencies and build the solution
+dotnet build
+
+# Run the unit test suite (NUnit)
+dotnet test
+```
 
 ## Running the application
 
-Add the text you wish to encode to the files/input.txt file. 
-Following the encoding of your message the result will be written to the files/output.txt
-When decoding a message, the output will be written to the files/decoded.txt
+The app is an interactive console menu. Because it reads and writes files using paths relative to the working directory, run it from inside the `cryptography` project folder:
 
-## To do
+```bash
+cd cryptography
+dotnet run
+```
 
-The following list details the next steps for this application. 
+### Encoding / decoding workflow
 
-- Add comprehensive unit test coverage.
-- Add better documentation to code.
-- Implement composite cipher (Started on branch).
-- Implement fiestel cipher. 
+The app uses three text files in `cryptography/files/`:
+
+| File | Purpose |
+|------|---------|
+| `input.txt` | The plaintext you want to encode |
+| `output.txt` | Where encoded (ciphertext) output is written |
+| `decoded.txt` | Where decoded (plaintext) output is written |
+
+1. Put the message you want to encode in `files/input.txt`.
+2. Run the app and select a cipher by number from the main menu.
+3. Choose **1. Encode** — the ciphertext is written to `files/output.txt`.
+4. To reverse it, select the cipher again and choose **2. Decode** — it reads `files/output.txt` and writes the recovered plaintext to `files/decoded.txt`.
+
+## Implemented ciphers
+
+Selected from the main menu:
+
+| # | Cipher | Type |
+|---|--------|------|
+| 1 | Caesar | Substitution |
+| 2 | Simple Substitution | Substitution |
+| 3 | Playfair | Substitution |
+| 4 | Vigenère | Substitution |
+| 5 | Simple Transposition | Transposition |
+| 6 | Rail Fence | Transposition |
+
+## Calculations
+
+Menu option **88** opens a calculations sub-menu covering the number theory behind these algorithms:
+
+| # | Calculation |
+|---|-------------|
+| 1 | Euler's totient function — ϕ(n) |
+| 2 | Greatest common divisor (GCD) |
+| 3 | Extended Euclidean algorithm |
+| 4 | Modulo calculator |
+
+## Project structure
+
+```
+cryptography/                 # Main console application
+  Program.cs                  # Entry point and main menu loop
+  HistoricCiphers/            # Cipher implementations (derive from Cipher)
+  Services/                   # Key generation, string ops, user interaction
+  Models/                     # Cipher, CipherList, CipherType, EeaResult
+  Calculations/               # GCD, Extended Euclid, totient, modulo
+  files/                      # input.txt / output.txt / decoded.txt
+cryptography.tests/           # NUnit test suite mirroring the source layout
+```
+
+## Roadmap
+
+- Implement a custom composite (product) cipher.
+- Implement a Feistel cipher.
+- Continue towards modern algorithms.
+- Expand unit test coverage and inline documentation.
+
+## License
+
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
Closes #4

## What

Expands the minimal (~10-line) README into full project documentation, updated to reflect the current state of the codebase.

### Sections added/updated
- **⚠️ Educational use only** disclaimer — these are historic, broken-by-design ciphers, not for real security
- **Prerequisites** — .NET 10 SDK (with `dotnet --list-sdks` check)
- **Build & test** — `dotnet build` / `dotnet test`
- **Running the application** — interactive menu walkthrough + the `files/` input/output/decoded convention, with the correct working directory
- **Implemented ciphers** table (Caesar, Simple Substitution, Playfair, Vigenère, Simple Transposition, Rail Fence)
- **Calculations** table (Euler's totient, GCD, Extended Euclid, modulo)
- **Project structure** overview
- **Roadmap** — refreshed (unit tests now exist; composite/Feistel ciphers + modern algorithms remain)
- **License** — MIT

## Verification

- Cipher/calculation lists and menu numbers cross-checked against `CipherList` and `UserInteractionService`
- Documented run command (`cd cryptography && dotnet run`) verified to encode correctly against the current build
- Only `README.md` changed (smoke-test output reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)