### PR TITLE
Add Vigenère unit tests

### DIFF
--- a/cryptography.tests/HistoricCiphersTests/VigenereCipherTests.cs
+++ b/cryptography.tests/HistoricCiphersTests/VigenereCipherTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using cryptography.HistoricCiphers;
+using NUnit.Framework;
+
+namespace cryptography.tests.HistoricCiphersTests
+{
+    public class VigenereCipherTests
+    {
+        
+        private const string Plaintext1 = "a";
+        private const string Plaintext2 = "b";
+        private const string Plaintext3 = "abcdefghijklmnopqrstuvwxyz";
+        private const string Plaintext4 = "This is a secret message";
+
+        private static readonly List<char> Key1 = new List<char>(){'q'};
+        private static readonly List<char> Key2 = new List<char>(){'g'};
+        private static readonly List<char> Key3 = new List<char>(){'a','b'};
+        private static readonly List<char> Key4 = new List<char>(){'a','b'};
+        
+        private const string Ciphertext1 = "q";
+        private const string Ciphertext2 = "h";
+        private const string Ciphertext3 = "nopqrstuvwxyzabcdefghijklm";
+        private const string Ciphertext4 = "Ymnx nx f xjhwjy rjxxflj";
+        
+        [Test]
+        [TestCase(Plaintext1, Key1, Ciphertext1)]
+        [TestCase(Plaintext2, Key2, Ciphertext2)]
+        [TestCase(Plaintext3, Key3, Ciphertext3)]
+        [TestCase(Plaintext4, Key4, Ciphertext4)]
+        public static void replaceValsEncodeTest(string inputValue, int skip, string expectedResult)
+        {
+            //Act
+            var actualResult = VigenereCipher.replaceValues(inputValue, skip);
+           
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+        
+        [Test]
+        [TestCase(Ciphertext1, 26-Key1, Plaintext1)]
+        [TestCase(Ciphertext2, 26-Key2, Plaintext2)]
+        [TestCase(Ciphertext3, 26-Key3, Plaintext3)]
+        [TestCase(Ciphertext4, 26-Key4, Plaintext4)]
+        public static void replaceValsDecodeTest(String inputValue, int skip, string expectedResult)
+        {
+            //Act
+            var actualResult = VigenereCipher.replaceValues(inputValue, skip);
+           
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+    }
+}

--- a/cryptography.tests/HistoricCiphersTests/VigenereCipherTests.cs
+++ b/cryptography.tests/HistoricCiphersTests/VigenereCipherTests.cs
@@ -1,54 +1,78 @@
 using System;
 using System.Collections.Generic;
 using cryptography.HistoricCiphers;
+using cryptography.Models;
 using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
 
 namespace cryptography.tests.HistoricCiphersTests
 {
     public class VigenereCipherTests
     {
-        
         private const string Plaintext1 = "a";
         private const string Plaintext2 = "b";
         private const string Plaintext3 = "abcdefghijklmnopqrstuvwxyz";
         private const string Plaintext4 = "This is a secret message";
+        // The cipher lowercases its input, so decoding returns the lowercase plaintext.
+        private const string DecodedPlaintext4 = "this is a secret message";
 
-        private static readonly List<char> Key1 = new List<char>(){'q'};
-        private static readonly List<char> Key2 = new List<char>(){'g'};
-        private static readonly List<char> Key3 = new List<char>(){'a','b'};
-        private static readonly List<char> Key4 = new List<char>(){'a','b'};
-        
+        private const string Key1 = "q";
+        private const string Key2 = "g";
+        private const string Key3 = "ab";
+        private const string Key4 = "ab";
+
         private const string Ciphertext1 = "q";
         private const string Ciphertext2 = "h";
-        private const string Ciphertext3 = "nopqrstuvwxyzabcdefghijklm";
-        private const string Ciphertext4 = "Ymnx nx f xjhwjy rjxxflj";
-        
+        private const string Ciphertext3 = "acceeggiikkmmooqqssuuwwyya";
+        private const string Ciphertext4 = "tiit js a sfcseu netsbgf";
+
         [Test]
         [TestCase(Plaintext1, Key1, Ciphertext1)]
         [TestCase(Plaintext2, Key2, Ciphertext2)]
         [TestCase(Plaintext3, Key3, Ciphertext3)]
         [TestCase(Plaintext4, Key4, Ciphertext4)]
-        public static void replaceValsEncodeTest(string inputValue, int skip, string expectedResult)
+        public void replaceValsEncodeTest(string inputValue, string keyPhrase, string expectedResult)
         {
+            //Arrange
+            var cipher = new VigenereCipher("Vigenère Cipher", CipherType.Substitution);
+            var key = generateFullKey(inputValue.Length, keyPhrase);
+
             //Act
-            var actualResult = VigenereCipher.replaceValues(inputValue, skip);
-           
+            var actualResult = cipher.replaceValues(inputValue, key, true);
+
             //Assert
             Assert.AreEqual(expectedResult, actualResult);
         }
-        
+
         [Test]
-        [TestCase(Ciphertext1, 26-Key1, Plaintext1)]
-        [TestCase(Ciphertext2, 26-Key2, Plaintext2)]
-        [TestCase(Ciphertext3, 26-Key3, Plaintext3)]
-        [TestCase(Ciphertext4, 26-Key4, Plaintext4)]
-        public static void replaceValsDecodeTest(String inputValue, int skip, string expectedResult)
+        [TestCase(Ciphertext1, Key1, Plaintext1)]
+        [TestCase(Ciphertext2, Key2, Plaintext2)]
+        [TestCase(Ciphertext3, Key3, Plaintext3)]
+        [TestCase(Ciphertext4, Key4, DecodedPlaintext4)]
+        public void replaceValsDecodeTest(string inputValue, string keyPhrase, string expectedResult)
         {
+            //Arrange
+            var cipher = new VigenereCipher("Vigenère Cipher", CipherType.Substitution);
+            var key = generateFullKey(inputValue.Length, keyPhrase);
+
             //Act
-            var actualResult = VigenereCipher.replaceValues(inputValue, skip);
-           
+            var actualResult = cipher.replaceValues(inputValue, key, false);
+
             //Assert
             Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        // replaceValues expects the key already repeated to the message length
+        // (one key character per position, including non-letters), as the
+        // cipher's private generateFullKey produces.
+        private static List<char> generateFullKey(int messageLength, string keyPhrase)
+        {
+            var key = new List<char>();
+            for (int i = 0; i < messageLength; i++)
+            {
+                key.Add(keyPhrase[i % keyPhrase.Length]);
+            }
+            return key;
         }
     }
 }

--- a/cryptography/HistoricCiphers/VigenereCipher.cs
+++ b/cryptography/HistoricCiphers/VigenereCipher.cs
@@ -56,7 +56,7 @@ namespace cryptography.HistoricCiphers
             File.WriteAllText(writeToFile, output);
         }
 
-        private string replaceValues(string fileString, List<char> key, bool encrypt)
+        public string replaceValues(string fileString, List<char> key, bool encrypt)
         {
             var csb = new StringBuilder(fileString.ToLower());
             var messageChars = fileString.ToLower().ToCharArray();


### PR DESCRIPTION
Finishes the old `vigenereUnitTests` branch so its value lands on `main`.

Closes #9

## What's here
- `VigenereCipher.replaceValues` made `private` → `public` (testability enabler, kept from the original 2022 commit)
- `cryptography.tests/HistoricCiphersTests/VigenereCipherTests.cs` rewritten to compile and pass:
  - Calls the real instance signature `replaceValues(text, key, encrypt)`; decode uses `encrypt: false` instead of the Caesar `26-key` idiom
  - Keys pass through `[TestCase]` as strings and are expanded to message length by a test helper (`List<char>` can't be a `[TestCase]` argument); the helper mirrors the private `generateFullKey`, including consuming a key char on non-letter positions
  - Multi-char expected ciphertexts recomputed for key `ab`: `abcdefghijklmnopqrstuvwxyz` → `acceeggiikkmmooqqssuuwwyya` (covers the z→a wrap) and `This is a secret message` → `tiit js a sfcseu netsbgf` (covers input lowercasing — decode asserts the lowercase plaintext)

## Verification
`dotnet test`: 78 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)